### PR TITLE
Fix clickos project URL

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -40,7 +40,7 @@ tagline:
 		  <article class="item">
 			<h3>ClickOS</h3>
 			<p>A high-performance, virtualized software middle box platform based on open source virtualization. Early performance analysis shows that ClickOS VMs are small (5MB), boot quickly (as little as 20 milliseconds), add little delay (45 microseconds) and more than 100 can be concurrently run while saturating a 10Gb pipe on an inexpensive commodity server.</p>
-			<p><a target="_blank" href="http://cnp.neclab.eu/clickos/">cnp.neclab.eu</a></p>
+			<p><a target="_blank" href="http://cnp.neclab.eu/projects/clickos/">cnp.neclab.eu</a></p>
 		  </article>
 		</div>
 		


### PR DESCRIPTION
It seems like the ClickOS project URL currently specified on the unikernel.org has changed. This pull request updates that to the current URL: http://cnp.neclab.eu/projects/clickos/